### PR TITLE
feat: warn about missing kde connect devices on startup

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -21,11 +21,11 @@ where
     v.into_iter().collect()
 }
 
-pub fn warn_on_err<T, E>(result: Result<T, E>) -> Option<T>
+pub fn warn_on_err<T, E>(prefix: &str, result: Result<T, E>) -> Option<T>
 where
     E: Display,
 {
-    result.map_err(|e| log::warn!("{}", e)).ok()
+    result.map_err(|e| log::warn!("{}: {}", prefix, e)).ok()
 }
 
 pub fn print_slice<T>(slice: &[T])
@@ -116,7 +116,7 @@ mod tests {
     fn test_warn_on_err_ok() {
         let r: Result<(), error::Error> = Ok(());
 
-        let result = warn_on_err(r);
+        let result = warn_on_err("test/common", r);
 
         assert_eq!(Some(()), result);
     }
@@ -128,7 +128,7 @@ mod tests {
                 model: error::Model(Some("test".into())),
             }));
 
-        let result = warn_on_err(r);
+        let result = warn_on_err("test/common", r);
 
         assert_eq!(None, result);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn notify(
         threshold,
         kde_connect_names.map(common::vec_to_set),
         disable_desktop,
-    );
+    )?;
 
     event::loop_(&mut battery_device, &mut notifier, refresh_secs)?;
 


### PR DESCRIPTION
- added prefix argument to `common::warn_on_err`

Signed-off-by: Lukas Kucera <85391931+kucera-lukas@users.noreply.github.com>